### PR TITLE
adds docker-compose with mariadb for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.5'
+
+services:
+  mariadb:
+    image: mariadb:10.0
+    container_name: mariadb
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
We will need various services as we build this app.  Rather than install these services locally, its much more convenient to run them in docker.  I've added a mariadb instance since we'll probably need that first, but we can add others as needed.